### PR TITLE
Fixed view recycling bug

### DIFF
--- a/ListAsGridAdapter/src/com/plattysoft/ui/ListAsGridBaseAdapter.java
+++ b/ListAsGridAdapter/src/com/plattysoft/ui/ListAsGridBaseAdapter.java
@@ -91,6 +91,27 @@ public abstract class ListAsGridBaseAdapter extends BaseAdapter {
 		return layout;
 	}
 
+    @Override
+    public int getViewTypeCount() {
+        // Not necessary for only 1 column
+        if (getNumColumns() == 1) return 1;
+
+        return 2;
+    }
+
+    @Override
+    public int getItemViewType(int position) {
+        // Not necessary for only 1 column
+        if (getNumColumns() == 1) return 0;
+
+        // If we have an odd item count and this is the last row, use the view type with filler views
+        if (getItemCount() % 2 != 0 && position == getCount() - 1) {
+            return 1;
+        }
+
+        return 0;
+    }
+
 	private LinearLayout createItemRow(int position, ViewGroup viewGroup, int columnWidth) {		
 		LinearLayout layout;
 		layout = new LinearLayout(mContext);


### PR DESCRIPTION
Added getViewTypeCount() and getItemViewType() overrides so that two view types are available - one for full rows, and another for the last row with filler views. This prevents getItemView() sometimes being called for full rows with the wrong view type (and potential crashes if you expect the view to have a view holder in its tag for example).
